### PR TITLE
Correction of non-existent return variable (insertOne does not work)

### DIFF
--- a/src/repository.js
+++ b/src/repository.js
@@ -31,7 +31,7 @@ module.exports = class Repository {
   async insert(entityInstance) {
     const payload = this.dataMapper.collectionFieldsWithValue(entityInstance)
 
-    let ret = await this
+    const ret = await this
       .runner()
       .collection(this.collectionQualifiedName)
       .insertOne(payload)

--- a/src/repository.js
+++ b/src/repository.js
@@ -31,9 +31,13 @@ module.exports = class Repository {
   async insert(entityInstance) {
     const payload = this.dataMapper.collectionFieldsWithValue(entityInstance)
 
-    let { ops } = await this.runner().collection(this.collectionQualifiedName).insertOne(payload)
+    let ret = await this
+      .runner()
+      .collection(this.collectionQualifiedName)
+      .insertOne(payload)
 
-    return this.dataMapper.toEntity(ops[0])
+    payload._id = ret.insertedId
+    return this.dataMapper.toEntity(payload)
   }
 
   /**

--- a/test/queries/insert.js
+++ b/test/queries/insert.js
@@ -42,7 +42,10 @@ describe("Insert an Entity", () => {
   it("should insert an entity", async () => {
     //given
     let spy = {}
-    const retFromDeb = { ops: [{ _id: ObjectID("60edc25fc39277307ca9a7ff") }] }
+    const retFromDeb = { 
+      insertedId: ObjectID("60edc25fc39277307ca9a7ff"),
+      acknowledged : true
+    }
     const collectionName = "aCollection"
     const anEntity = givenAnEntity()
     const ItemRepository = givenAnRepositoryClass()
@@ -63,6 +66,6 @@ describe("Insert an Entity", () => {
     //then
     assert.deepStrictEqual(ret.id,  "60edc25fc39277307ca9a7ff")
     assert.deepStrictEqual(spy.collectionName, collectionName)
-    assert.deepStrictEqual(spy.payload, { _id: "60edc25fc39277307ca9a7ff", number_test: 100, boolean_test: true })
+    assert.deepStrictEqual(spy.payload, { id: "60edc25fc39277307ca9a7ff", number_test: 100, boolean_test: true })
   })
 })


### PR DESCRIPTION
[Insert method doesn't work issue](https://github.com/herbsjs/herbs2mongo/issues/3)

Fixes #

The error happens in the third step of the method, when we try to convert the return payload from the database to a valid gotu entity:

![image](https://user-images.githubusercontent.com/66751918/131235290-0dd6599e-c470-4b42-9eff-98aaa719b838.png)

## Proposed Changes

If the idea is to return the entity inserted in the database, we can concatenate the payload we received in the method and with the id generated by the insertion and then convert it into a valid entity and return the result.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [x] `bug`
