### PR TITLE
Save and find nested entities

### DIFF
--- a/src/dataMapper.js
+++ b/src/dataMapper.js
@@ -115,8 +115,6 @@ class DataMapper {
 
       return parsedEntity
     }
-
-    return { [field.nameDb]: value }
   }
 
   collectionFieldsWithValue(instance) {

--- a/src/dataMapper.js
+++ b/src/dataMapper.js
@@ -45,13 +45,13 @@ class DataMapper {
 
         const object = { name: field, type, isEntity, nameDb, isArray, isID }
 
-        if(isEntity) {
+        if (isEntity) {
           const entitySchema = isArray
             ? schema[field].type[0].prototype.meta.schema
             : schema[field].type.prototype.meta.schema
           object.children = this.buildAllFields(entitySchema, [], convention)
         }
-        
+
         return object
       })
       .filter(Boolean)
@@ -152,14 +152,14 @@ class DataMapper {
         return (value) => arrayDataParser(value, parser)
       }
 
-      if(isArrayOfEntities) {
+      if (isArrayOfEntities) {
         return (value) => {
           if (checker.isEmpty(value)) return null
           return value?.map((item) => {
             const object = Object.keys(item).reduce((obj, key) => {
               const childField = field?.children.find((i) => i.nameDb === key)
 
-              if(childField.isEntity) {
+              if (childField.isEntity) {
                 obj[childField.name] = processEntity(childField, item)
 
                 return obj
@@ -184,7 +184,7 @@ class DataMapper {
     const convention = this.convention
     const proxy = {}
 
-    function processEntity (field, payload) {
+    function processEntity(field, payload) {
       const entityValue = payload[field.nameDb]
 
       if (checker.isEmpty(entityValue)) return undefined
@@ -194,10 +194,10 @@ class DataMapper {
 
         const isEntity = entity.isEntity(entityField.type)
 
-        if(isEntity) {
+        if (isEntity) {
           const childField = field?.children.find((i) => i.name === entityField.name)
 
-          if(childField.isArray) {
+          if (childField.isArray) {
             const arrayOfEntityParser = getDataParser(childField.type, childField.isArray, childField.isEntity, childField)
             obj[entityField.name] = arrayOfEntityParser(payload[field.nameDb][fieldNameDb])
 
@@ -240,7 +240,7 @@ class DataMapper {
             return processEntity(field, this._payload)
           }
 
-          if(field.isEntity && field.isArray) {
+          if (field.isEntity && field.isArray) {
             const arrayOfEntityParser = getDataParser(field.type, field.isArray, field.isEntity, field)
             return arrayOfEntityParser(this._payload[nameDb])
           }

--- a/src/dataMapper.js
+++ b/src/dataMapper.js
@@ -58,15 +58,31 @@ class DataMapper {
 
   collectionFields() {
     return this.allFields
-      .filter((i) => !i.isEntity)
       .map((i) => i.nameDb)
+  }
+
+  filterNullAndUndefined(i, instance) {
+    if (instance[i.name] === null || instance[i.name] === undefined) return null
+    if (i.isEntity) {
+      const entity = instance[i.name]
+      const newObject = Object.keys(entity).reduce((acc, key) => {
+        if (entity[key] === null || entity[key] === undefined) return acc
+
+        acc[key] = entity[key]
+
+        return acc
+      }, {})
+
+      return { [i.nameDb]: newObject }
+    }
+    return { [i.nameDb]: instance[i.name] }
   }
 
   collectionFieldsWithValue(instance) {
 
     let collectionFields = this.allFields
-      .filter((i) => !i.isEntity)
-      .map(i => ({ [i.nameDb]: instance[i.name] }))
+      .map(i => this.filterNullAndUndefined(i, instance))
+      .filter(Boolean)
       .reduce((x, y) => ({ ...x, ...y }))
 
     if (instance.id === undefined) {

--- a/src/dataMapper.js
+++ b/src/dataMapper.js
@@ -1,5 +1,5 @@
 const Convention = require('./convention')
-const { entity } = require('@herbsjs/herbs')
+const { entity, checker } = require('@herbsjs/herbs')
 const dependency = { convention: Convention }
 
 class DataMapper {
@@ -101,7 +101,7 @@ class DataMapper {
 
     function getDataParser(type, isArray) {
       function arrayDataParser(value, parser) {
-        if (value === null) return null
+        if (checker.isEmpty(value)) return null
         return value.map((i) => parser(i))
       }
 

--- a/src/dataMapper.js
+++ b/src/dataMapper.js
@@ -94,27 +94,25 @@ class DataMapper {
         acc[index] = curr
         return acc
       }, {})
-    }    
-
-    if(field.isEntity) {
-      const parsedEntity = Object.keys(value).reduce((acc, key) => {
-        if (value[key] === null || value[key] === undefined) return acc
-    
-          const childField = field.children.find((i) => i.name === key)
-  
-          if(childField?.isEntity) {
-            acc[childField.nameDb] = this.parseEntity(childField, value[key])
-
-            return acc
-          }
-  
-        acc[childField.nameDb] = value[key]
-  
-        return acc
-      }, {})
-
-      return parsedEntity
     }
+
+    const parsedEntity = Object.keys(value).reduce((acc, key) => {
+      if (value[key] === null || value[key] === undefined) return acc
+
+      const childField = field.children.find((i) => i.name === key)
+
+      if (childField?.isEntity) {
+        acc[childField.nameDb] = this.parseEntity(childField, value[key])
+
+        return acc
+      }
+
+      acc[childField.nameDb] = value[key]
+
+      return acc
+    }, {})
+
+    return parsedEntity
   }
 
   collectionFieldsWithValue(instance) {

--- a/src/dataMapper.js
+++ b/src/dataMapper.js
@@ -44,14 +44,11 @@ class DataMapper {
         const isID = entityIDs.includes(field)
 
         const object = { name: field, type, isEntity, nameDb, isArray, isID }
-  
-        if(isEntity && !isArray) {
-          const entitySchema = schema[field].type.prototype.meta.schema
-          object.children = this.buildAllFields(entitySchema, [], convention)
-        }
 
-        if (isEntity && isArray) {
-          const entitySchema = schema[field].type[0].prototype.meta.schema
+        if(isEntity) {
+          const entitySchema = isArray
+            ? schema[field].type[0].prototype.meta.schema
+            : schema[field].type.prototype.meta.schema
           object.children = this.buildAllFields(entitySchema, [], convention)
         }
         

--- a/src/dataMapper.js
+++ b/src/dataMapper.js
@@ -192,7 +192,11 @@ class DataMapper {
       const object = field.type.schema.fields.reduce((obj, entityField) => {
         const fieldNameDb = convention.toCollectionFieldName(entityField.name)
 
-        const isEntity = entity.isEntity(entityField.type)
+        const typeIsArray = checker.isArray(entityField.type)
+
+        const isEntity = typeIsArray
+          ? entity.isEntity(entityField.type[0])
+          : entity.isEntity(entityField.type)
 
         if (isEntity) {
           const childField = field?.children.find((i) => i.name === entityField.name)

--- a/src/dataMapper.js
+++ b/src/dataMapper.js
@@ -142,7 +142,7 @@ class DataMapper {
       Object.defineProperty(proxy, field.name, {
         enumerable: true,
         get: function () {
-          if (field.isEntity) return undefined
+          if (field.isEntity) return parser(this._payload[nameDb])
           return parser(this._payload[nameDb])
         }
       })

--- a/src/dataMapper.js
+++ b/src/dataMapper.js
@@ -68,18 +68,21 @@ class DataMapper {
 
   transformField(field, instance) {
     if (field.isEntity) {
-      const entityToFilter = instance[field.name]
-      const parsedEntity = Object.keys(entityToFilter).reduce((acc, key) => {
-        if (entityToFilter[key] === null || entityToFilter[key] === undefined) return acc
-
-        acc[key] = entityToFilter[key]
-
-        return acc
-      }, {})
-
-      return { [field.nameDb]: parsedEntity }
+      return { [field.nameDb]: this.parseEntity(instance[field.name]) }
     }
     return { [field.nameDb]: instance[field.name] }
+  }
+
+  parseEntity(value) {
+    const parsedEntity = Object.keys(value).reduce((acc, key) => {
+      if (value[key] === null || value[key] === undefined) return acc
+
+      acc[key] = value[key]
+
+      return acc
+    }, {})
+
+    return parsedEntity
   }
 
   collectionFieldsWithValue(instance) {

--- a/src/dataMapper.js
+++ b/src/dataMapper.js
@@ -142,7 +142,21 @@ class DataMapper {
       Object.defineProperty(proxy, field.name, {
         enumerable: true,
         get: function () {
-          if (field.isEntity) return parser(this._payload[nameDb])
+          if (field.isEntity && !field.isArray) {
+            const entity = this._payload[field.nameDb]
+
+            if (checker.isEmpty(entity)) return undefined
+
+            const object = field.type.schema.fields.reduce((obj, entityField) => {
+              const fieldNameDb = convention.toCollectionFieldName(entityField.name)
+              const fieldParser = getDataParser(entityField.type, Array.isArray(entityField.type))
+
+              obj[entityField.name] = fieldParser(this._payload[field.nameDb][fieldNameDb])
+              return obj
+            }, {})
+
+            return object
+          }
           return parser(this._payload[nameDb])
         }
       })

--- a/src/herbs2mongo.js
+++ b/src/herbs2mongo.js
@@ -1,3 +1,4 @@
 const Repository = require('./repository')
+const DataMapper = require('./dataMapper')
 
-module.exports = { Repository }
+module.exports = { Repository, DataMapper }

--- a/test/dataMapper.test.js
+++ b/test/dataMapper.test.js
@@ -38,7 +38,6 @@ describe('Data Mapper', () => {
             assert.deepStrictEqual(toEntity.idField, 1)
             assert.deepStrictEqual(toEntity.field1, true)
             assert.deepStrictEqual(toEntity.fieldName, false)
-
         })
 
         it('should convert an entity field to the collection string convetion', () => {
@@ -99,10 +98,11 @@ describe('Data Mapper', () => {
     })
 
     describe('Simple Nested Entity', () => {
+        const ChildEntity = entity('Child entity', {
+            field1: field(String)
+        })
+
         const givenAnNestedEntity = () => {
-            const ChildEntity = entity('Child entity', {
-                field1: field(String)
-            })
 
             return entity('A nested entity', {
                 idField: field(Number),
@@ -111,6 +111,33 @@ describe('Data Mapper', () => {
                 arrayChildEntity: field([ChildEntity])
             })
         }
+
+        it('should convert data from collection to nested entity', () => {
+            //given
+            const Entity = givenAnNestedEntity()
+            const entityIDs = ['idField']
+            const dataMapper = new DataMapper(Entity, entityIDs)
+            const childEntity = new ChildEntity()
+            childEntity.field1 = 'String'
+
+            //when
+            const toEntity = dataMapper.toEntity({
+                id_field: 1,
+                field1: true,
+                child_entity: {
+                    field1: 'String'
+                },
+                array_child_entity: [
+                    { field1: 'String' }
+                ]
+            })
+
+            //then
+            assert.deepStrictEqual(toEntity.idField, 1)
+            assert.deepStrictEqual(toEntity.field1, true)
+            assert.deepStrictEqual(toEntity.childEntity, childEntity)
+            assert.deepStrictEqual(toEntity.arrayChildEntity, [childEntity])
+        })
 
         it('should retrieve collection fields an nested entity', () => {
             //given

--- a/test/dataMapper.test.js
+++ b/test/dataMapper.test.js
@@ -98,7 +98,7 @@ describe('Data Mapper', () => {
     })
 
     describe('Simple Nested Entity', () => {
-        const GreatGreatGrandChildEntity = entity('Great-Grand Child entity', {
+        const GreatGreatGrandChildEntity = entity('Great Great-Grand Child entity', {
             simpleString: field(String),
             simpleBoolean: field(Boolean)
         })

--- a/test/dataMapper.test.js
+++ b/test/dataMapper.test.js
@@ -98,8 +98,16 @@ describe('Data Mapper', () => {
     })
 
     describe('Simple Nested Entity', () => {
+        const GreatGreatGrandChildEntity = entity('Great-Grand Child entity', {
+            simpleString: field(String),
+            simpleBoolean: field(Boolean)
+        })
+
         const GreatGrandChildEntity = entity('Great-Grand Child entity', {
-            simpleString: field(String)
+            simpleString: field(String),
+            simpleNumber: field(Number),
+            simpleStringArray: field([String]),
+            greatGreatGrandChild: field([GreatGreatGrandChildEntity])
         })
 
         const GrandChildEntity = entity('Grand Child entity', {
@@ -131,6 +139,11 @@ describe('Data Mapper', () => {
             childEntity.simpleString = 'String'
             childEntity.grandChild.greatGrandChild = new GreatGrandChildEntity()
             childEntity.grandChild.greatGrandChild.simpleString = 'String'
+            childEntity.grandChild.greatGrandChild.simpleStringArray = ['String']
+            childEntity.grandChild.greatGrandChild.simpleNumber = 1
+            childEntity.grandChild.greatGrandChild.greatGreatGrandChild = [GreatGreatGrandChildEntity.fromJSON({
+                simpleString: 'String'
+            })]
 
             //when
             const toEntity = dataMapper.toEntity({
@@ -139,7 +152,16 @@ describe('Data Mapper', () => {
                 child_entity: {
                     grand_child: {
                         great_grand_child: {
-                            simple_string: 'String'
+                            simple_string: 'String',
+                            simple_string_array: [
+                                'String'
+                            ],
+                            simple_number: 1,
+                            great_great_grand_child: [
+                                {
+                                    simple_string: 'String'
+                                }
+                            ]
                         }
                     },
                     simple_string: 'String'
@@ -148,7 +170,16 @@ describe('Data Mapper', () => {
                     {
                         grand_child: {
                             great_grand_child: {
-                                simple_string: 'String'
+                                simple_string: 'String',
+                                simple_string_array: [
+                                    'String'
+                                ],
+                                simple_number: 1,
+                                great_great_grand_child: [
+                                    {
+                                        simple_string: 'String'
+                                    }
+                                ]
                             }
                         },
                         simple_string: 'String'
@@ -191,7 +222,12 @@ describe('Data Mapper', () => {
             entityInstance.childEntity = {
                 grandChild: {
                     greatGrandChild: {
-                        simpleString: 'String'
+                        simpleString: 'String',
+                        greatGreatGrandChild: [
+                            {
+                                simpleString: 'String'
+                            }
+                        ]
                     }
                 },
                 simpleString: 'String'
@@ -219,7 +255,12 @@ describe('Data Mapper', () => {
                 child_entity: {
                     grand_child: {
                         great_grand_child: {
-                            simple_string: 'String'
+                            simple_string: 'String',
+                            great_great_grand_child: {
+                                '0': {
+                                    simple_string: 'String'
+                                }
+                            }
                         }
                     },
                     simple_string: 'String'

--- a/test/dataMapper.test.js
+++ b/test/dataMapper.test.js
@@ -107,7 +107,8 @@ describe('Data Mapper', () => {
         })
 
         const ChildEntity = entity('Child entity', {
-            grandChild: field(GrandChildEntity)
+            grandChild: field(GrandChildEntity),
+            simpleString: field(String)
         })
 
         const givenAnNestedEntity = () => {
@@ -127,6 +128,7 @@ describe('Data Mapper', () => {
             const dataMapper = new DataMapper(Entity, entityIDs)
             const childEntity = new ChildEntity()
             childEntity.grandChild = new GrandChildEntity()
+            childEntity.simpleString = 'String'
             childEntity.grandChild.greatGrandChild = new GreatGrandChildEntity()
             childEntity.grandChild.greatGrandChild.simpleString = 'String'
 
@@ -139,7 +141,8 @@ describe('Data Mapper', () => {
                         great_grand_child: {
                             simple_string: 'String'
                         }
-                    }
+                    },
+                    simple_string: 'String'
                 },
                 array_child_entity: [
                     {
@@ -147,7 +150,8 @@ describe('Data Mapper', () => {
                             great_grand_child: {
                                 simple_string: 'String'
                             }
-                        }
+                        },
+                        simple_string: 'String'
                     }
                 ]
             })
@@ -189,7 +193,8 @@ describe('Data Mapper', () => {
                     greatGrandChild: {
                         simpleString: 'String'
                     }
-                }
+                },
+                simpleString: 'String'
             }
             entityInstance.arrayChildEntity = [
                 {
@@ -197,7 +202,8 @@ describe('Data Mapper', () => {
                         greatGrandChild: {
                             simpleString: 'String'
                         }
-                    }
+                    },
+                    simpleString: 'String'
                 }
             ]
             const entityIDs = ['idField']
@@ -215,7 +221,8 @@ describe('Data Mapper', () => {
                         great_grand_child: {
                             simple_string: 'String'
                         }
-                    }
+                    },
+                    simple_string: 'String'
                 },
                 array_child_entity: {
                     0: {
@@ -223,7 +230,8 @@ describe('Data Mapper', () => {
                             great_grand_child: {
                                 simple_string: 'String'
                             }
-                        }
+                        },
+                        simple_string: 'String'
                     }
                 }
             })

--- a/test/dataMapper.test.js
+++ b/test/dataMapper.test.js
@@ -147,9 +147,9 @@ describe('Data Mapper', () => {
             childEntity.grandChild.greatGrandChild.simpleString = 'String'
             childEntity.grandChild.greatGrandChild.simpleStringArray = ['String']
             childEntity.grandChild.greatGrandChild.simpleNumber = 1
-            childEntity.grandChild.greatGrandChild.greatGreatGrandChild = [GreatGreatGrandChildEntity.fromJSON({
-                simpleString: 'String'
-            })]
+            const greatGreatGrandChild = new GreatGreatGrandChildEntity()
+            greatGreatGrandChild.simpleString = 'String'
+            childEntity.grandChild.greatGrandChild.greatGreatGrandChild = [greatGreatGrandChild]
 
             //when
             const toEntity = dataMapper.toEntity({

--- a/test/dataMapper.test.js
+++ b/test/dataMapper.test.js
@@ -110,14 +110,20 @@ describe('Data Mapper', () => {
             greatGreatGrandChild: field([GreatGreatGrandChildEntity])
         })
 
+        const CousinEntity = entity('Cousin entity', {
+            greatGrandChildEntity: field(GreatGrandChildEntity)
+        })
+
         const GrandChildEntity = entity('Grand Child entity', {
-            greatGrandChild: field(GreatGrandChildEntity)
+            greatGrandChild: field(GreatGrandChildEntity),
+            cousin: field(CousinEntity)
         })
 
         const ChildEntity = entity('Child entity', {
             grandChild: field(GrandChildEntity),
             simpleString: field(String)
         })
+        
 
         const givenAnNestedEntity = () => {
 
@@ -161,8 +167,9 @@ describe('Data Mapper', () => {
                                 {
                                     simple_string: 'String'
                                 }
-                            ]
-                        }
+                            ],
+                            cousin: null
+                        },
                     },
                     simple_string: 'String'
                 },
@@ -227,7 +234,8 @@ describe('Data Mapper', () => {
                             {
                                 simpleString: 'String'
                             }
-                        ]
+                        ],
+                        cousin: null
                     }
                 },
                 simpleString: 'String'

--- a/test/dataMapper.test.js
+++ b/test/dataMapper.test.js
@@ -148,7 +148,7 @@ describe('Data Mapper', () => {
             childEntity.grandChild.greatGrandChild.simpleStringArray = ['String']
             childEntity.grandChild.greatGrandChild.simpleNumber = 1
             const greatGreatGrandChild = new GreatGreatGrandChildEntity()
-            greatGreatGrandChild.simpleString = 'String'
+            greatGreatGrandChild.simpleString = 'greatGreatGrandChildEntity'
             childEntity.grandChild.greatGrandChild.greatGreatGrandChild = [greatGreatGrandChild]
 
             //when
@@ -165,7 +165,7 @@ describe('Data Mapper', () => {
                             simple_number: 1,
                             great_great_grand_child: [
                                 {
-                                    simple_string: 'String'
+                                    simple_string: 'greatGreatGrandChildEntity'
                                 }
                             ],
                             cousin: null
@@ -184,7 +184,7 @@ describe('Data Mapper', () => {
                                 simple_number: 1,
                                 great_great_grand_child: [
                                     {
-                                        simple_string: 'String'
+                                        simple_string: 'greatGreatGrandChildEntity'
                                     }
                                 ]
                             }

--- a/test/dataMapper.test.js
+++ b/test/dataMapper.test.js
@@ -98,6 +98,90 @@ describe('Data Mapper', () => {
         })
     })
 
+    describe('Simple Nested Entity', () => {
+        const givenAnNestedEntity = () => {
+            const ChildEntity = entity('Child entity', {
+                field1: field(String)
+            })
+
+            return entity('A nested entity', {
+                idField: field(Number),
+                field1: field(Boolean),
+                childEntity: field(ChildEntity),
+                arrayChildEntity: field([ChildEntity])
+            })
+        }
+
+        it('should retrieve collection fields an nested entity', () => {
+            //given
+            const Entity = givenAnNestedEntity()
+            const entityInstance = new Entity()
+            entityInstance.idField = 1
+            entityInstance.field1 = true
+            entityInstance.childEntity = {
+                field1: 'String'
+            }
+            const entityIDs = ['idField']
+            const dataMapper = new DataMapper(Entity, entityIDs)
+
+            //when
+            const toEntity = dataMapper.collectionFields()
+
+            //then
+            assert.deepStrictEqual(toEntity, ['id_field', 'field1', 'child_entity', 'array_child_entity'])
+        })
+
+        it('should retrieve collection fields with values of an nested entity', () => {
+            //given
+            const Entity = givenAnNestedEntity()
+            const entityInstance = new Entity()
+            entityInstance.idField = 1
+            entityInstance.field1 = true
+            entityInstance.childEntity = {
+                field1: 'String'
+            }
+            entityInstance.arrayChildEntity = [
+                {
+                    field1: 'String'
+                }
+            ]
+            const entityIDs = ['idField']
+            const dataMapper = new DataMapper(Entity, entityIDs)
+
+            //when
+            const toEntity = dataMapper.collectionFieldsWithValue(entityInstance)
+
+            //then
+            assert.deepStrictEqual(toEntity, {
+                id_field: 1,
+                field1: true,
+                child_entity: {
+                    field1: 'String'
+                },
+                array_child_entity: {
+                    0: { field1: 'String' }
+                }
+            })
+        })
+
+        it('should retrieve collection fields with values of an nested entity with child entity as empty object', () => {
+            //given
+            const Entity = givenAnNestedEntity()
+            const entityInstance = new Entity()
+            entityInstance.idField = 1
+            entityInstance.field1 = true
+            entityInstance.childEntity = {}
+            const entityIDs = ['idField']
+            const dataMapper = new DataMapper(Entity, entityIDs)
+
+            //when
+            const toEntity = dataMapper.collectionFieldsWithValue(entityInstance)
+
+            //then
+            assert.deepStrictEqual(toEntity, { id_field: 1, field1: true, child_entity: {} })
+        })
+    })
+
     describe('Complex Entity - Multiple Types', () => {
 
         const givenAnComplexEntity = () => {

--- a/test/dataMapper.test.js
+++ b/test/dataMapper.test.js
@@ -98,8 +98,16 @@ describe('Data Mapper', () => {
     })
 
     describe('Simple Nested Entity', () => {
+        const GreatGrandChildEntity = entity('Great-Grand Child entity', {
+            simpleString: field(String)
+        })
+
+        const GrandChildEntity = entity('Grand Child entity', {
+            greatGrandChild: field(GreatGrandChildEntity)
+        })
+
         const ChildEntity = entity('Child entity', {
-            field1: field(String)
+            grandChild: field(GrandChildEntity)
         })
 
         const givenAnNestedEntity = () => {
@@ -118,17 +126,29 @@ describe('Data Mapper', () => {
             const entityIDs = ['idField']
             const dataMapper = new DataMapper(Entity, entityIDs)
             const childEntity = new ChildEntity()
-            childEntity.field1 = 'String'
+            childEntity.grandChild = new GrandChildEntity()
+            childEntity.grandChild.greatGrandChild = new GreatGrandChildEntity()
+            childEntity.grandChild.greatGrandChild.simpleString = 'String'
 
             //when
             const toEntity = dataMapper.toEntity({
                 id_field: 1,
                 field1: true,
                 child_entity: {
-                    field1: 'String'
+                    grand_child: {
+                        great_grand_child: {
+                            simple_string: 'String'
+                        }
+                    }
                 },
                 array_child_entity: [
-                    { field1: 'String' }
+                    {
+                        grand_child: {
+                            great_grand_child: {
+                                simple_string: 'String'
+                            }
+                        }
+                    }
                 ]
             })
 
@@ -165,11 +185,19 @@ describe('Data Mapper', () => {
             entityInstance.idField = 1
             entityInstance.field1 = true
             entityInstance.childEntity = {
-                field1: 'String'
+                grandChild: {
+                    greatGrandChild: {
+                        simpleString: 'String'
+                    }
+                }
             }
             entityInstance.arrayChildEntity = [
                 {
-                    field1: 'String'
+                    grandChild: {
+                        greatGrandChild: {
+                            simpleString: 'String'
+                        }
+                    }
                 }
             ]
             const entityIDs = ['idField']
@@ -183,10 +211,20 @@ describe('Data Mapper', () => {
                 id_field: 1,
                 field1: true,
                 child_entity: {
-                    field1: 'String'
+                    grand_child: {
+                        great_grand_child: {
+                            simple_string: 'String'
+                        }
+                    }
                 },
                 array_child_entity: {
-                    0: { field1: 'String' }
+                    0: {
+                        grand_child: {
+                            great_grand_child: {
+                                simple_string: 'String'
+                            }
+                        }
+                    }
                 }
             })
         })

--- a/test/queries/find.js
+++ b/test/queries/find.js
@@ -134,7 +134,7 @@ describe('Query Find', () => {
             const ret = await itemRepo.find({ filter: { stringTest: ["aString"] } })
 
             //then
-            assert.deepStrictEqual(ret[0].toJSON(), { id: '60edc25fc39277307ca9a7ff', stringTest: "aString",  numberTest: 100, booleanTest: true , entityTest: undefined, entitiesTest: undefined })
+            assert.deepStrictEqual(ret[0].toJSON(), { id: '60edc25fc39277307ca9a7ff', stringTest: "aString",  numberTest: 100, booleanTest: true , entityTest: undefined, entitiesTest: null })
             assert.deepStrictEqual(ret[0].isValid(),true )
 
         })

--- a/test/queries/findByID.js
+++ b/test/queries/findByID.js
@@ -64,7 +64,7 @@ describe('Query Find by ID', () => {
         const ret = await itemRepo.findByID(anEntity.id)
 
         //then
-        assert.deepStrictEqual(ret[0].toJSON(), { id: '60edc25fc39277307ca9a7ff', stringTest: "aString",  numberTest: 100, booleanTest: true , entityTest: undefined, entitiesTest: undefined })
+        assert.deepStrictEqual(ret[0].toJSON(), { id: '60edc25fc39277307ca9a7ff', stringTest: "aString",  numberTest: 100, booleanTest: true , entityTest: undefined, entitiesTest: null })
         assert.deepStrictEqual(ret[0].isValid(),true )
 
     })

--- a/testdb/findByID.js
+++ b/testdb/findByID.js
@@ -8,34 +8,48 @@ let client = {}
 
 describe('Query Find by ID', () => {
 
-  const collection = 'test_repository'
-  const database = 'herbs2mongo_testdb'
+    const collection = 'test_repository'
+    const database = 'herbs2mongo_testdb'
 
     before(async () => {
 
-      client = await connection()
+        client = await connection()
 
-      await client.dropDatabase()
+        await client.dropDatabase()
 
-      await client.createCollection(collection)
+        await client.createCollection(collection)
 
-      await client.collection(collection).insertOne({ _id: new ObjectId("60edc25fc39277307ca9a7ff"), number_test: 100, boolean_test: true, string_test: 'aString' })
-      await client.collection(collection).insertOne({ _id: new ObjectId("70edc25fc39277307ca9a700"), number_test: 200, boolean_test: false })
-      await client.collection(collection).insertOne({ _id: new ObjectId("80edd25fc39272307ca9a712"), number_test: 300, boolean_test: false })
-      await client.collection(collection).insertOne({
-          _id: new ObjectId("64acbc1ba6a28fbd4501c25c"),
-          number_test: 400,
-          boolean_test: true,
-          string_test: "aString",
-          child_entity: {
-              number_test: 100, boolean_test: true, string_test: 'aString'
-          }
-      })
+        await client.collection(collection).insertOne({ _id: new ObjectId("60edc25fc39277307ca9a7ff"), number_test: 100, boolean_test: true, string_test: 'aString' })
+        await client.collection(collection).insertOne({ _id: new ObjectId("70edc25fc39277307ca9a700"), number_test: 200, boolean_test: false })
+        await client.collection(collection).insertOne({ _id: new ObjectId("80edd25fc39272307ca9a712"), number_test: 300, boolean_test: false })
+        await client.collection(collection).insertOne({
+            _id: new ObjectId("64acbc1ba6a28fbd4501c25c"),
+            number_test: 400,
+            boolean_test: true,
+            string_test: "aString",
+            child_entity: {
+                number_test: 100,
+                boolean_test: true,
+                string_test: 'aString',
+                grand_child_test: {
+                    number_test: 100,
+                    boolean_test: true,
+                    string_test: 'aString',
+                    array_entities_test: [
+                        {
+                            number_test: 100,
+                            boolean_test: true,
+                            string_test: 'aString',
+                        }
+                    ]
+                }
+            }
+        })
     })
 
     after(async () => {
 
-      await client.dropDatabase()
+        await client.dropDatabase()
 
     })
 
@@ -47,11 +61,26 @@ describe('Query Find by ID', () => {
         }
     }
 
+    const GreatGrandChildEntity = entity('Great-Grand child entity', {
+        numberTest: field(Number),
+        stringTest: field(String),
+        booleanTest: field(Boolean),
+    })
+
+    const GrandChildEntity = entity('Grand child entity', {
+        numberTest: field(Number),
+        stringTest: field(String),
+        booleanTest: field(Boolean),
+        arrayTest: field([String]),
+        arrayEntitiesTest: field([GreatGrandChildEntity])
+    })
+
     const ChildEntity = entity('Child entity', {
         numberTest: field(Number),
         stringTest: field(String),
         booleanTest: field(Boolean),
-        arrayTest: field([String])
+        arrayTest: field([String]),
+        grandChildTest: field(GrandChildEntity)
     })
 
     const givenAnEntity = () => {
@@ -110,7 +139,19 @@ describe('Query Find by ID', () => {
             booleanTest: true,
             stringTest: "aString",
             childEntity: {
-                numberTest: 100, booleanTest: true, stringTest: 'aString', arrayTest: null,
+                numberTest: 100, booleanTest: true, stringTest: 'aString', arrayTest: null, grandChildTest: {
+                    numberTest: 100,
+                    booleanTest: true,
+                    stringTest: 'aString',
+                    arrayTest: null,
+                    arrayEntitiesTest: [
+                        {
+                            numberTest: 100,
+                            booleanTest: true,
+                            stringTest: 'aString'
+                        }
+                    ]
+                }
             }
         })
         assert.deepStrictEqual(ret[0].isValid(), true)

--- a/testdb/findByID.js
+++ b/testdb/findByID.js
@@ -19,9 +19,18 @@ describe('Query Find by ID', () => {
 
       await client.createCollection(collection)
 
-      await client.collection(collection).insertOne( { _id: new ObjectId("60edc25fc39277307ca9a7ff"), number_test: 100, boolean_test: true, string_test: 'aString' })
-      await client.collection(collection).insertOne( { _id: new ObjectId("70edc25fc39277307ca9a700"), number_test: 200, boolean_test: false })
-      await client.collection(collection).insertOne( { _id: new ObjectId("80edd25fc39272307ca9a712"), number_test: 300, boolean_test: false })
+      await client.collection(collection).insertOne({ _id: new ObjectId("60edc25fc39277307ca9a7ff"), number_test: 100, boolean_test: true, string_test: 'aString' })
+      await client.collection(collection).insertOne({ _id: new ObjectId("70edc25fc39277307ca9a700"), number_test: 200, boolean_test: false })
+      await client.collection(collection).insertOne({ _id: new ObjectId("80edd25fc39272307ca9a712"), number_test: 300, boolean_test: false })
+      await client.collection(collection).insertOne({
+          _id: new ObjectId("64acbc1ba6a28fbd4501c25c"),
+          number_test: 400,
+          boolean_test: true,
+          string_test: "aString",
+          child_entity: {
+              number_test: 100, boolean_test: true, string_test: 'aString'
+          }
+      })
     })
 
     after(async () => {
@@ -38,16 +47,24 @@ describe('Query Find by ID', () => {
         }
     }
 
+    const ChildEntity = entity('Child entity', {
+        numberTest: field(Number),
+        stringTest: field(String),
+        booleanTest: field(Boolean),
+        arrayTest: field([String])
+    })
+
     const givenAnEntity = () => {
         return entity('A entity', {
             id: field(String),
             numberTest: field(Number),
             stringTest: field(String),
-            booleanTest: field(Boolean)
+            booleanTest: field(Boolean),
+            childEntity: field(ChildEntity)
         })
     }
 
-    it('should return entities', async () => {
+    it('should return entity', async () => {
         //given
         const anEntity = givenAnEntity()
         const ItemRepository = givenAnRepositoryClass({
@@ -65,8 +82,38 @@ describe('Query Find by ID', () => {
         const ret = await itemRepo.findByID(anEntity.id)
 
         //then
-        assert.deepStrictEqual(ret[0].toJSON(), { id: '60edc25fc39277307ca9a7ff', stringTest: "aString",  numberTest: 100, booleanTest: true })
-        assert.deepStrictEqual(ret[0].isValid(),true )
+        assert.deepStrictEqual(ret[0].toJSON(), { id: '60edc25fc39277307ca9a7ff', stringTest: "aString", numberTest: 100, booleanTest: true, childEntity: undefined })
+        assert.deepStrictEqual(ret[0].isValid(), true)
+    })
+
+    it('should return nested entitiy', async () => {
+        //given
+        const anEntity = givenAnEntity()
+        const ItemRepository = givenAnRepositoryClass({
+            entity: anEntity,
+            collection,
+            database,
+            ids: ['id'],
+            mongodb: await connection
+        })
+        const injection = {}
+        const itemRepo = new ItemRepository(injection)
+
+        anEntity.id = '64acbc1ba6a28fbd4501c25c'
+        //when
+        const ret = await itemRepo.findByID(anEntity.id)
+
+        //then
+        assert.deepStrictEqual(ret[0].toJSON(), {
+            id: '64acbc1ba6a28fbd4501c25c',
+            numberTest: 400,
+            booleanTest: true,
+            stringTest: "aString",
+            childEntity: {
+                numberTest: 100, booleanTest: true, stringTest: 'aString', arrayTest: null,
+            }
+        })
+        assert.deepStrictEqual(ret[0].isValid(), true)
     })
 
     it('should return multiple entities', async () => {
@@ -81,17 +128,17 @@ describe('Query Find by ID', () => {
         })
         const injection = {}
         const itemRepo = new ItemRepository(injection)
-      
+
         const ids = [
             '60edc25fc39277307ca9a7ff',
             '80edd25fc39272307ca9a712',
-          ]
+        ]
 
         //when
         const ret = await itemRepo.findByID(ids)
 
         //then
-        assert.deepStrictEqual(ret[0].toJSON(), { id: '60edc25fc39277307ca9a7ff', stringTest: "aString",  numberTest: 100, booleanTest: true })
-        assert.deepStrictEqual(ret[0].isValid(),true )
+        assert.deepStrictEqual(ret[0].toJSON(), { id: '60edc25fc39277307ca9a7ff', stringTest: "aString", numberTest: 100, booleanTest: true, childEntity: undefined })
+        assert.deepStrictEqual(ret[0].isValid(), true)
     })
 })


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

This pull request aims to implement a feature that will allow inserting and finding entities that contain fields that are entities (or array of entities), which in this context, I called nested entities.
This is related to issue #35
I also added export DataMapper class in Herbs2Mongo.js to allow developer to extend this class and create their own custom DataMapper.
I'm already covering a previous case reported in the issue, in which the collection was missing in the database containing the `meta` field that is inherited from BaseEntity, however, I'm not covering the `errors` field, which for now can be covered by developers simply doing a delete on the object before calling the find method, as this is a feature that will be addressed in the issue: https://github.com/herbsjs/gotu/issues/71
These changes do not implement breaking changes.
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. [Adjusts collectionFieldsWithValues method to save nested entities](https://github.com/herbsjs/herbs2mongo/commit/d62cb04653e6e76a567df3eb100507654aab546e)
2. [Adjusts collectionFields method to not remove entities](https://github.com/herbsjs/herbs2mongo/pull/37/commits/4f460aed4295659494dc8bcf97106600b63165b4)
3. [Adjust buildProxy to maps the entity's internal fields and returns an object with these fields filled in](https://github.com/herbsjs/herbs2mongo/pull/37/commits/4f460aed4295659494dc8bcf97106600b63165b4)
4. [Improved empty object checking in arrayDataParse](https://github.com/herbsjs/herbs2mongo/commit/2453cb72df917923f8ca668f1fe40890e8c0c2dc)
5. [Enable export of DataMapper class](https://github.com/herbsjs/herbs2mongo/commit/e34049e124aee6b660b28574d530cb3bdf29eed4)

## Screenshots
Nested entity in find method return:
![Find](https://github.com/herbsjs/herbs2mongo/assets/8906065/217abde0-a0a6-4f0b-a581-03c3e2c23afd)
Nested entity that was saved to the database:
![MongoDB Compass](https://github.com/herbsjs/herbs2mongo/assets/8906065/aaf04889-b073-4020-8030-678f346f239e)




## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
